### PR TITLE
Fix/remove black and isort (#226)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install detect-secrets
-        run: pip install --no-cache-dir detect-secrets doc8 isort==5.11.5
+        run: pip install --no-cache-dir detect-secrets doc8
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
 
@@ -58,6 +58,8 @@ jobs:
           - "3.10"
           - "3.9"
 #          - "3.8"
+    env:
+      PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
     steps:
       - name: Clean-up
         run: sudo apt clean && sudo apt autoclean && sudo rm -rf /tmp/* && sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,13 +32,13 @@ repos:
       - id: debug-statements
       - id: check-merge-conflict
 
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
-        name: black
-        files: .
-        args: [ "--config", "pyproject.toml" ]
+#  - repo: https://github.com/psf/black
+#    rev: 24.4.2
+#    hooks:
+#      - id: black
+#        name: black
+#        files: .
+#        args: [ "--config", "pyproject.toml" ]
 
 #  - repo: https://github.com/pycqa/isort
 #    rev: 5.13.2
@@ -54,7 +54,7 @@ repos:
       - id: ruff
         name: lint
         files: .
-        args: [ "--config", "pyproject.toml" ]
+        args: [ "--config", "pyproject.toml", "--fix" ]
 
   - repo: https://github.com/jsh9/pydoclint
     rev: 0.4.2

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -38,14 +38,15 @@ standards.
 
 Code standards
 --------------
-`black`_, `isort`_, `ruff`_ and `doc8`_ will be automatically triggered by
-`pre-commit`_. Still, if you want to run checks manually:
+`ruff`_ and `doc8`_ will be automatically triggered by `pre-commit`_.
+
+`ruff`_ is configured to do the job of `black`_ and `isort`_ as well.
+
+Still, if you want to run checks manually:
 
 .. code-block:: sh
 
-    make black
     make doc8
-    make isort
     make ruff
 
 Requirements

--- a/Makefile
+++ b/Makefile
@@ -21,23 +21,26 @@ build_docs_epub:
 build_docs_pdf:
 	$(MAKE) -C docs/ latexpdf
 
+auto_build_docs:
+	source $(VENV) && sphinx-autobuild docs docs/_build/html
+
 pre-commit:
 	pre-commit run --all-files
 
-# Format code using Black
-black:
-	source $(VENV) && black .
-
-# Sort imports using isort
-isort:
-	source $(VENV) && isort . --overwrite-in-place
+## Format code using Black
+#black:
+#	source $(VENV) && black .
+#
+## Sort imports using isort
+#isort:
+#	source $(VENV) && isort . --overwrite-in-place
 
 doc8:
 	source $(VENV) && doc8
 
 # Run ruff on the codebase
 ruff:
-	source $(VENV) && ruff .
+	source $(VENV) && ruff check .
 
 # Serve the built docs on port 5001
 serve_docs:

--- a/examples/customization/address/factories.py
+++ b/examples/customization/address/factories.py
@@ -1,8 +1,8 @@
 from fake import ModelFactory, SubFactory, post_save, pre_save
-from override_default_data import FACTORY as OVERRIDE_DEFAULT_DATA_FACTORY
 
 from address.models import Address, Person
 from fake_address import FACTORY as ADDRESS_FACTORY
+from override_default_data import FACTORY as OVERRIDE_DEFAULT_DATA_FACTORY
 
 __author__ = "Artur Barseghyan <artur.barseghyan@gmail.com>"
 __copyright__ = "2023-2024 Artur Barseghyan"

--- a/examples/customization/band/factories.py
+++ b/examples/customization/band/factories.py
@@ -1,6 +1,6 @@
-from band.models import Band
 from fake import ModelFactory
 
+from band.models import Band
 from fake_band import FACTORY
 
 __author__ = "Artur Barseghyan <artur.barseghyan@gmail.com>"

--- a/examples/customization/band/tests.py
+++ b/examples/customization/band/tests.py
@@ -1,8 +1,9 @@
 import unittest
 
+from fake import FILE_REGISTRY
+
 from band.factories import BandFactory
 from band.models import Band
-from fake import FILE_REGISTRY
 
 __author__ = "Artur Barseghyan <artur.barseghyan@gmail.com>"
 __copyright__ = "2023-2024 Artur Barseghyan"

--- a/examples/customization/custom_data_cli.py
+++ b/examples/customization/custom_data_cli.py
@@ -1,4 +1,5 @@
 from fake import CLI
+
 from override_default_data import FAKER
 
 

--- a/examples/hypothesis/tests.py
+++ b/examples/hypothesis/tests.py
@@ -3,7 +3,8 @@ import unittest
 from decimal import Decimal
 
 from fake import FAKER, FILE_REGISTRY, StringValue, slugify
-from hypothesis import Verbosity, given, settings, strategies as st
+from hypothesis import Verbosity, given, settings
+from hypothesis import strategies as st
 
 __author__ = "Artur Barseghyan <artur.barseghyan@gmail.com>"
 __copyright__ = "2023-2024 Artur Barseghyan"

--- a/fake.py
+++ b/fake.py
@@ -63,7 +63,7 @@ from typing import (
     get_origin,
     get_type_hints,
 )
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import UUID
 
 __title__ = "fake.py"
@@ -2020,7 +2020,10 @@ class Faker:
     def email(self, domain_names: Optional[Tuple[str, ...]] = None) -> str:
         """Generate a random email."""
         domain = random.choice(domain_names) if domain_names else None
-        return f"{self.word().lower()}@{domain or self.domain_name()}"
+        return (
+                f"{'.'.join(_w.lower() for _w in self.words(3))}"
+                f"@{domain or self.domain_name()}"
+        )
 
     @provider(tags=("Internet",))
     def company_email(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,11 @@ Changelog = "https://fakepy.readthedocs.io/en/latest/changelog.html"
 [project.optional-dependencies]
 all = ["fake.py[dev,test,docs]"]
 dev = [
-    "black",
+#    "black",
     "detect-secrets",
     "doc8",
     "ipython",
-    "isort",
+#    "isort",
     "mypy",
     "pip-tools",
     "pydoclint",
@@ -60,6 +60,7 @@ test = [
 ]
 docs = [
     "sphinx<6.0",
+    "sphinx-autobuild",
     "sphinx-rtd-theme>=1.3.0",
     "sphinx-no-pragma",
 ]
@@ -79,49 +80,62 @@ include = ["fakepy"]
 requires = ["setuptools>=41.0", "setuptools-scm", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.black]
-line-length = 80
-target-version = ['py38', 'py39', 'py310', 'py311']
-include = '\.pyi?$'
-force-exclude = '__copy_fake\.py'
-extend-exclude = '''
-/(
-  # The following are specific to Black, you probably don't want those.
-  | blib2to3
-  | tests/data
-  | profiling
-  | migrations
-)/
-'''
-
-[tool.isort]
-profile = "black"
-combine_as_imports = true
-multi_line_output = 3
-force_single_line = false
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 80
-honor_noqa = true
-known_first_party = [
-    "address",
-    "article",
-    "config",
-    "data",
-    "fake_address",
-    "fake_band",
-]
-known_third_party = ["fake"]
-skip = ["wsgi.py", "builddocs/"]
+#[tool.black]
+#line-length = 80
+#target-version = ['py38', 'py39', 'py310', 'py311']
+#include = '\.pyi?$'
+#force-exclude = '__copy_fake\.py'
+#extend-exclude = '''
+#/(
+#  # The following are specific to Black, you probably don't want those.
+#  | blib2to3
+#  | tests/data
+#  | profiling
+#  | migrations
+#)/
+#'''
+#
+#[tool.isort]
+#profile = "black"
+#combine_as_imports = true
+#multi_line_output = 3
+#force_single_line = false
+#include_trailing_comma = true
+#force_grid_wrap = 0
+#use_parentheses = true
+#ensure_newline_before_comments = true
+#line_length = 80
+#honor_noqa = true
+#known_first_party = [
+#    "address",
+#    "article",
+#    "config",
+#    "data",
+#    "fake_address",
+#    "fake_band",
+#]
+#known_third_party = ["fake"]
+#skip = ["wsgi.py", "builddocs/"]
 
 [tool.ruff]
 line-length = 80
 
 # Enable Pyflakes `E` and `F` codes by default.
-lint.select = ["E", "F"]
+lint.select = ["E", "F", "I"]
 lint.ignore = []
+# Enable autofix for formatting and import sorting
+fix = true
+src = [
+    "examples/customization",
+    "examples/dataclasses",
+    "examples/django",
+    "examples/hypothesis",
+    "examples/lazyfuzzy",
+    "examples/pydantic",
+    "examples/sqlalchemy",
+    "examples/sqlmodel",
+    "examples/tortoise",
+]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -151,8 +165,19 @@ lint.per-file-ignores = {}
 # Allow unused variables when underscore-prefixed.
 lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.8.
-target-version = "py38"
+# Assume Python 3.9.
+target-version = "py39"
+
+[tool.ruff.lint.isort]
+known-first-party = [
+    "address",
+    "article",
+    "config",
+    "data",
+    "fake_address",
+    "fake_band",
+]
+known-third-party = []
 
 [tool.doc8]
 ignore-path = [


### PR DESCRIPTION
* Update `ruff` config to do the job of `black` and `isort`.
* Remove `black` and `isort`.
* Update pre-commit and GitHub Actions accordingly.
* Fixes for future Python checks.