### PR TITLE
Test all integration examples against Python 3.13 (#252)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         #          - Windows
         #          - MacOs
         python-version:
-          - "3.14.0-alpha.3"
+          - "3.14.0-alpha.5"
           - "3.13"
           - "3.12"
           - "3.11"
@@ -100,6 +100,7 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -135,6 +136,7 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -170,6 +172,7 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -217,6 +220,7 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -253,6 +257,7 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -289,6 +294,7 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -325,6 +331,7 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -361,6 +368,7 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"


### PR DESCRIPTION
* Test all integration examples against Python 3.13
* Update Python3.14 from 3.14.0-alpha.3 to 3.14.0-alpha.5 on GitHub CI